### PR TITLE
chore: release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8](https://github.com/BobG1983/rantz_spatial2d/compare/v0.3.7...v0.3.8) - 2024-06-19
+
+### Other
+- Adding release-plz as CI
+
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,7 +1994,7 @@ checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "rantz_spatial2d"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "bevy",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rantz_spatial2d"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["Robert Gardner'"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `rantz_spatial2d`: 0.3.7 -> 0.3.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.8](https://github.com/BobG1983/rantz_spatial2d/compare/v0.3.7...v0.3.8) - 2024-06-19

### Other
- Adding release-plz as CI
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).